### PR TITLE
binary data visualisation fixes

### DIFF
--- a/chrome/content/Renderers.js
+++ b/chrome/content/Renderers.js
@@ -84,7 +84,7 @@ Copper.renderBinary = function(message) {
 		if (i % 16 == 15) {
 			Copper.updateLabel('packet_payload', ' | ', true);
 			for (var j=i-15; j<=i; ++j) {
-				if (pl[j] < 32) {
+				if (pl[j] < 32 || pl[j] >= 127) {
 					Copper.updateLabel('packet_payload', '·', true);
 				} else {
 					Copper.updateLabel('packet_payload', String.fromCharCode(pl[j] & 0xFF), true);

--- a/chrome/content/coap/CoapRFC7252.js
+++ b/chrome/content/coap/CoapRFC7252.js
@@ -510,24 +510,30 @@ Copper.bytes2str = function(b) {
 		
 		let c = b[i] & 0xFF;
 		
-		if (c < 128 || !Copper.utf8) {
+		if (c == 10 || (c >= 32 && c < 127)) {
 			str += String.fromCharCode(c);
-		} else if((c > 191) && (c < 224) && (i+1 < b.length)) {
+		} else if(Copper.utf8 && (c > 191) && (c < 224) && (i+1 < b.length) && (b[i+1] & 0xc0) == 0x80) {
 			let c2 = b[i+1] & 0xFF;
 			str += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
 			i += 1;
-		} else if (c < 240 && (i+2 < b.length)) {
+		} else if (Copper.utf8 && c >= 224 && c < 240 && (i+2 < b.length) && (b[i+1] & 0xc0) == 0x80 && (b[i+2] & 0xc0) == 0x80) {
 			let c2 = b[i+1] & 0xFF;
 			let c3 = b[i+2] & 0xFF;
 			str += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
 			i += 2;
-		} else if (i+3 < b.length) {
+		} else if (Copper.utf8 && c >= 240 && i+3 < b.length) {
 			Copper.logEvent('4-byte UTF-8');
 			str += String.fromCharCode(0xFFFD); // char '�'
 			i += 3;
-		} else {
+		} else if (Copper.utf8 && c >= 128) {
 			Copper.logEvent('Incomplete UTF-8 encoding');
 			str += String.fromCharCode(0xFFFD); // char '�'
+		} else {
+			if (c < 32)
+				str += String.fromCharCode(0x2400 + c); // replacement character block
+			else
+				str += String.fromCharCode(0xFFFD); // char '�'
+//			str += "\\x" + (c < 16 ? "0" : "") + c.toString(16);
 		}
 	}
 	return str;

--- a/chrome/content/coap/CoapRFC7252.js
+++ b/chrome/content/coap/CoapRFC7252.js
@@ -512,14 +512,16 @@ Copper.bytes2str = function(b) {
 		
 		if (c == 10 || (c >= 32 && c < 127)) {
 			str += String.fromCharCode(c);
-		} else if(Copper.utf8 && (c > 191) && (c < 224) && (i+1 < b.length) && (b[i+1] & 0xc0) == 0x80) {
-			let c2 = b[i+1] & 0xFF;
-			str += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
+		} else if(Copper.utf8 && c >= 192 && c < 224 && (i+1 < b.length) && (b[i+1] & 0xc0) == 0x80) {
+			let c1 = c & 0x1f;
+			let c2 = b[i+1] & 0x3F;
+			str += String.fromCharCode((c1 << 6) | c2);
 			i += 1;
 		} else if (Copper.utf8 && c >= 224 && c < 240 && (i+2 < b.length) && (b[i+1] & 0xc0) == 0x80 && (b[i+2] & 0xc0) == 0x80) {
-			let c2 = b[i+1] & 0xFF;
-			let c3 = b[i+2] & 0xFF;
-			str += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
+			let c1 = c & 0x0f;
+			let c2 = b[i+1] & 0x3F;
+			let c3 = b[i+2] & 0x3F;
+			str += String.fromCharCode((c1 << 12) | (c2 << 6) | c3);
 			i += 2;
 		} else if (Copper.utf8 && c >= 240 && i+3 < b.length) {
 			Copper.logEvent('4-byte UTF-8');


### PR DESCRIPTION
looking at binary data (eg. memory dumps) using copper looks quite messy. the attached patches make the hex view always align nicely by limiting it to printable characters, and narrows down the criteria for utf8 decoding in bytes2str (eg. in the message log) to only produce unicode characters when the affeced bytes really look like unicode.

some cleanup on existing code in that area is included for enhanced readability.