### PR TITLE
Renderers: Clear binary renderer output before updating with added content

### DIFF
--- a/chrome/content/Renderers.js
+++ b/chrome/content/Renderers.js
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Copyright (c) 2014, Institute for Pervasive Computing, ETH Zurich.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -13,7 +13,7 @@
  * 3. Neither the name of the Institute nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -25,7 +25,7 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- * 
+ *
  * This file is part of the Copper (Cu) CoAP user-agent.
  ******************************************************************************/
 /**
@@ -46,7 +46,7 @@ Copper.renderText = function(message) {
 		// view corresponding render element
 		document.getElementById('rendered_img').style.display = 'none';
 		document.getElementById('rendered_div').style.display = 'block';
-		
+
 		document.getElementById('tab_rendered').style.backgroundColor = str.toLowerCase();
 		document.getElementById('tabs_payload').selectedIndex = 1;
 	} else {
@@ -56,16 +56,16 @@ Copper.renderText = function(message) {
 };
 
 Copper.renderImage = function(message) {
-	
+
 	if (!message.getBlock2More()) {
 		// only render binary when transfer is complete (binary is heavy)
 		Copper.renderBinary(message);
 	}
-	
+
 	// view corresponding render element
 	document.getElementById('rendered_div').style.display = 'none';
 	document.getElementById('rendered_img').style.display = 'block';
-	
+
 	// causes flickering, but partially added data does not draw anyway
 	document.getElementById('rendered_img').src = 'data:'+Copper.getContentFormatName(message.getContentFormat())+';base64,'+btoa( Copper.bytes2data(message.getPayload()) );
 	document.getElementById('tab_rendered').style.backgroundColor = '';
@@ -73,77 +73,81 @@ Copper.renderImage = function(message) {
 };
 
 Copper.renderBinary = function(message) {
-	
+
 	var pl = message.getPayload();
-	
-	// TODO: loop is too heavy for large payloads, alternatives?
+
+	// Clear content first
+	Copper.updateLabel('packet_payload', '', false);
+	var line = '';
 	for (var i in pl) {
-		
-		Copper.updateLabel('packet_payload', Copper.leadingZero(pl[i].toString(16).toUpperCase()), true);
-		
+		line += Copper.leadingZero(pl[i].toString(16).toUpperCase());
+
 		if (i % 16 == 15) {
-			Copper.updateLabel('packet_payload', ' | ', true);
+			line += ' | ';
 			for (var j=i-15; j<=i; ++j) {
 				if (pl[j] < 32 || pl[j] >= 127) {
-					Copper.updateLabel('packet_payload', '·', true);
+					line += '·';
 				} else {
-					Copper.updateLabel('packet_payload', String.fromCharCode(pl[j] & 0xFF), true);
+					line += String.fromCharCode(pl[j] & 0xFF);
 				}
 			}
-			Copper.updateLabel('packet_payload', '\n', true);
+			line += '\n';
+			Copper.updateLabel('packet_payload', line, true);
+			line = '';
 		} else if (i % 2 == 1) {
-			Copper.updateLabel('packet_payload', ' ', true);
+			line += ' ';
 		}
 	}
-	
+
 	// incomplete lines
 	if ((parseInt(i)+1) % 16 != 0) {
 		// complete line with spaces
 		for (var j=0; j<39-((parseInt(i)+1)%16)*2 - ((parseInt(i)+1)%16)/2; ++j) {
-			Copper.updateLabel('packet_payload', ' ', true);
+			line += ' ';
 		}
-		
-		Copper.updateLabel('packet_payload', ' | ', true);
+
+		line += ' | ';
 		for (var j=i-(i%16); j<=i; ++j) {
 			if (pl[j] < 32) {
-				Copper.updateLabel('packet_payload', '·', true);
+				line += '·';
 			} else {
-				Copper.updateLabel('packet_payload', String.fromCharCode(pl[j] & 0xFF), true);
+				line += String.fromCharCode(pl[j] & 0xFF);
 			}
 		}
+		Copper.updateLabel('packet_payload', line, true);
 	}
-	
+
 	document.getElementById('tabs_payload').selectedIndex = 0;
 };
 
 
 Copper.renderLinkFormat = function(message) {
-	
+
 	// Print raw Link Format in case parsing fails
 	Copper.renderText(message);
-	
+
 	// The box for output at the top-level
 	document.getElementById('rendered_img').style.display = 'none';
     var view = document.getElementById('rendered_div');
     view.style.display = 'block';
-    
+
     while (view.hasChildNodes()) {
     	view.removeChild(view.firstChild);
     }
     view.setAttribute("class", "link-content");
-    
+
 	var parsedObj = Copper.parseLinkFormat( Copper.bytes2str(message.getPayload()) );
-	
+
 	view.appendChild( Copper.renderLinkFormatUtils.getXulLinks(parsedObj) );
-	
+
 	document.getElementById('tab_rendered').style.backgroundColor = '';
 	document.getElementById('tabs_payload').selectedIndex = 1;
 };
 
 Copper.renderLinkFormatUtils = {
-	
+
 	htmlns: "http://www.w3.org/1999/xhtml",
-	
+
 	getXulLinks: function(value) {
 		if (typeof value != 'object') {
 			return null;
@@ -153,10 +157,10 @@ Copper.renderLinkFormatUtils = {
 		for (var uri in value) {
 			this.addXulLink(xulObj, value[uri], uri);
 		}
-		
+
 		return xulObj;
 	},
-	 
+
 	addXulLink: function(xulObj, attribs, key) {
 
 		var xulChild = document.createElementNS(this.htmlns, "li");
@@ -169,9 +173,9 @@ Copper.renderLinkFormatUtils = {
 
 		xulObj.appendChild(xulChild);
 	},
- 
+
 	getXulObject: function(value) {
-		
+
 		if (typeof value != 'object') {
 			return null;
 		}
@@ -190,10 +194,10 @@ Copper.renderLinkFormatUtils = {
 				this.addXulChild(xulObj, value[prop], prop);
 			}
 		}
-		
+
 		return xulObj;
 	},
-	 
+
 	addXulChild: function(xulObj, value, key) {
 
 		var xulChild = document.createElementNS(this.htmlns, "li");
@@ -225,12 +229,12 @@ Copper.renderLinkFormatUtils = {
 					return xulObj;
 				}
 				return null;
-	
+
 			case 'string':
 				xulObj.appendChild( document.createTextNode(String(value)) );
 				xulObj.setAttribute("class", "string");
 				return xulObj;
-	
+
 			case 'number':
 				xulObj.setAttribute("value", isFinite(value) ? String(value) : 'null');
 				if (Math.floor(value) == value) {
@@ -239,17 +243,17 @@ Copper.renderLinkFormatUtils = {
 					xulObj.setAttribute("class", "float");
 				}
 				return xulObj;
-	
+
 			case 'boolean':
 				xulObj.setAttribute("value", String(value));
 				xulObj.setAttribute("class", "bool");
 				return xulObj;
-	
+
 			case 'null':
 				xulObj.setAttribute("value", String(value));
 				xulObj.setAttribute("class", "null");
 				return xulObj;
-				
+
 			default:
 				return null;
 		}
@@ -257,22 +261,22 @@ Copper.renderLinkFormatUtils = {
 };
 
 Copper.renderJSON = function(message) {
-	
+
 	// Print raw JSON in case parsing fails
 	Copper.renderText(message);
-	
+
 	// The box for output at the top-level
 	document.getElementById('rendered_img').style.display = 'none';
     var view = document.getElementById('rendered_div');
     view.style.display = 'block';
-    
+
     while (view.hasChildNodes()) {
     	view.removeChild(view.firstChild);
     }
     view.setAttribute("class", "json-content");
-    
+
     var pl = Copper.bytes2str(message.getPayload()).replace(/'/g, '"');
-    
+
 	try {
 		// Parse the JSON
 		var parsedObj = JSON.parse(pl);
@@ -287,13 +291,13 @@ Copper.renderJSON = function(message) {
 	} catch (ex) {
 		Copper.logError(ex);
 	}
-	
+
 };
 
 Copper.renderJSONutils = {
-		
+
 	htmlns: "http://www.w3.org/1999/xhtml",
- 
+
 	getXulObject: function(value) {
 		if (typeof value != 'object') {
 			return null;
@@ -309,7 +313,7 @@ Copper.renderJSONutils = {
 				label.setAttribute("value", "(length " + value.length + ")");
 				label.setAttribute("style", "color: gray;");
 				xulObj.appendChild(label);
-				
+
 				for (var i = 0; i < value.length; i ++) {
 					this.addXulChild(xulObj, value[i]);
 				}
@@ -318,7 +322,7 @@ Copper.renderJSONutils = {
 				label.setAttribute("value", "    ");
 				xulObj.appendChild(label);
 			}
-			
+
 		} else {
 			// object
 			xulObj.setAttribute("class", "object");
@@ -326,10 +330,10 @@ Copper.renderJSONutils = {
 				this.addXulChild(xulObj, value[prop], prop);
 			}
 		}
-		
+
 		return xulObj;
 	},
-	 
+
 	addXulChild: function(xulObj, value, key) {
 
 		var xulChild = document.createElementNS(this.htmlns, "li");
@@ -361,12 +365,12 @@ Copper.renderJSONutils = {
 					return xulObj;
 				}
 				return null;
-	
+
 			case 'string':
 				xulObj.appendChild( document.createTextNode(String(value)) );
 				xulObj.setAttribute("class", "string");
 				return xulObj;
-	
+
 			case 'number':
 				xulObj.setAttribute("value", isFinite(value) ? String(value) : 'null');
 				if (Math.floor(value) == value) {
@@ -375,17 +379,17 @@ Copper.renderJSONutils = {
 					xulObj.setAttribute("class", "float");
 				}
 				return xulObj;
-	
+
 			case 'boolean':
 				xulObj.setAttribute("value", String(value));
 				xulObj.setAttribute("class", "bool");
 				return xulObj;
-	
+
 			case 'null':
 				xulObj.setAttribute("value", String(value));
 				xulObj.setAttribute("class", "null");
 				return xulObj;
-				
+
 			default:
 				return null;
 		}


### PR DESCRIPTION
 - Bugfix: Don't render the same content over and over
 - Improved performance for large payloads by buffering each line of output.

Without this change my Firefox locks up for minutes when loading a 4096 byte file using 128 byte block size. The main problem was that the renderer was called over and over with the same content and appending each time.