### PR TITLE
Allow CoAP resource paths that contain the word "keys"

### DIFF
--- a/content/ResourceViews.js
+++ b/content/ResourceViews.js
@@ -79,7 +79,7 @@ Copper.addTreeResource = function(uri, attributes) {
 		
 		var cur = null;
 		var nodeChildren = null;
-		for (var k in node.childNodes) {
+		for (var k of Object.keys(node.childNodes)) {
 			if (node.childNodes[k].nodeName=='treechildren') {
 				nodeChildren = node.childNodes[k];
 				break;
@@ -87,7 +87,7 @@ Copper.addTreeResource = function(uri, attributes) {
 		}
 		
 		// getElementsByName() would be nice
-		for (var j in nodeChildren.childNodes) {
+		for (var j of Object.keys(nodeChildren.childNodes)) {
 			if (nodeChildren.childNodes[j] && nodeChildren.childNodes[j].name && nodeChildren.childNodes[j].name==segments[i]) {
 				cur = nodeChildren.childNodes[j];
 				break;


### PR DESCRIPTION
I stumbled upon this bug while doing a "Discover" for a CoAP resource with the path/name `keys`, which yielded this error:

```
ERROR: Message callback failed:
nodeChildren is null
	Copper.addTreeResource@chrome://copper/content/ResourceViews.js:90:1
	Copper.updateResourceLinks@chrome://copper/content/Helpers.js:455:3
Copper.discoverHandler@chrome://copper/content/Handlers.js:218:5
handle@chrome://copper/content/coap/TransactionHandler.js:321:5
Copper.myBind/<@chrome://copper/content/Helpers.js:647:9
onDataAvailable@chrome://copper/content/coap/UdpClient.js:112:23
```

Upon investigating I found out that this bug was caused by using the `for .. in` syntax in `copper/content/ResourceViews.js:90`  (which includes prototype properties):
```
> for (var j in nodeChildren.childNodes) {
  console.log(j);
}

0 
item 
keys 
values 
entries 
forEach 
length 
```

instead of including a `hasOwnProperty` check or using `for .. of Object.keys(..)`:
```
for (var j of Object.keys(nodeChildren.childNodes)) {
  console.log(j);
}

0
```

This resulted in an error if a coap resource was named the same as one of the `NodeList` prototype properties (e.g.: keys, item, ...).

This PR fixes this issue, I replaced the two occurrences of `for .. in` that I saw, but it would probably be beneficial to scan the code for more.